### PR TITLE
Add NPM Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,18 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "dashboard"
+    schedule:
+      interval: "daily"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      typescript:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/dependabot.yml` file to add a new configuration for the `npm` package ecosystem in the `dashboard` directory. The changes specify the update schedule, target branch, and group settings for TypeScript updates.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R19-R33): Added a new `npm` package ecosystem configuration for the `dashboard` directory with a daily update schedule at 01:00 in the Europe/London timezone, targeting the `main` branch, and grouping TypeScript updates for patch and minor versions.
