### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  build-site:
+    name: Build Site
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3.0.2
+        with:
+          path: dashboard
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build-site
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate deployment to GitHub Pages. The workflow is triggered by pushes to the `main` branch, manual dispatch, or a scheduled cron job.

### New GitHub Actions Workflow for Deployment:

* `.github/workflows/deploy.yml`: Added a workflow named "Deploy to GitHub Pages" with two jobs:
  - [`build-site`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R47): Checks out the repository, builds the site using the `withastro/action`, and prepares it for deployment.
  - [`deploy`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R47): Deploys the built site to GitHub Pages using the `actions/deploy-pages` action. This job is dependent on the `build-site` job.