### PR TITLE
Run UI Tests on Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,24 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4.0.5
 
+  ui-tests:
+    name: UI Tests
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python Dependencies
+        uses: ./.github/actions/setup-python-dependencies
+      - name: Install Playwright Dependencies
+        shell: bash
+        run: just tests::playwright-install
+      - name: Run UI Tests
+        run: just tests::ui-tests
+
   link-tests:
     name: Link Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to automate UI testing using Playwright. The most important change is the addition of the `ui-tests` job, which ensures UI tests are run after the build-and-deploy process.

### Workflow enhancements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R46-R63): Added a new `ui-tests` job that runs on `ubuntu-latest`. This job includes steps for checking out the repository, setting up Python dependencies, installing Playwright dependencies, and running UI tests using predefined `just` commands. The job is dependent on the successful completion of the `build-and-deploy` job.