### PR TITLE
Add Link Checking Tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
+
+  ui-tests:
+    name: UI Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python Dependencies
+        uses: ./.github/actions/setup-python-dependencies
+      - name: Install Playwright Dependencies
+        shell: bash
+        run: just tests::playwright-install-minimum
+      - name: Run UI Tests
+        run: just tests::ui-tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,24 +46,6 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4.0.5
 
-  ui-tests:
-    name: UI Tests
-    runs-on: ubuntu-latest
-    needs: deploy
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Python Dependencies
-        uses: ./.github/actions/setup-python-dependencies
-      - name: Install Playwright Dependencies
-        shell: bash
-        run: just tests::playwright-install-minimum
-      - name: Run UI Tests
-        run: just tests::ui-tests
-
   link-tests:
     name: Link Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,3 +63,21 @@ jobs:
         run: just tests::playwright-install-minimum
       - name: Run UI Tests
         run: just tests::ui-tests
+
+  link-tests:
+    name: Link Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Link Tests
+        uses: JustinBeckwith/linkinator-action@v1.11.0
+        with:
+          paths: https://jackplowman.github.io/project-links
+          recurse: true
+          timeout: 1000
+          markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to perform link testing after deployment. The new job ensures that all links on the deployed site are functional.

Workflow enhancements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R48-R65): Introduced a `link-tests` job that runs after the deployment to GitHub Pages. It uses the `linkinator-action` to verify the validity of links on the deployed site (`https://jackplowman.github.io/project-links`) with recursive checking and a timeout of 1000ms.
