### PR TITLE
Switch pip to uv in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
           - "patch"
           - "minor"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "tests"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to update the package ecosystem used for dependency updates in the `tests` directory.

Configuration update:

* Changed the `package-ecosystem` from `pip` to `uv` for dependency updates in the `tests` directory.