### PR TITLE
Fix NPM Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "minor"
 
   - package-ecosystem: "npm"
-    directory: "dashboard"
+    directory: "website"
     schedule:
       interval: "daily"
       time: "01:00"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to update the directory path for the npm package ecosystem from "dashboard" to "website".

Configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L21-R21): Changed the `directory` path for the npm package ecosystem from "dashboard" to "website".
