### PR TITLE
Add custom links and icon

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,13 +10,14 @@
         "@tailwindcss/vite": "4.1.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-icons": "5.5.0",
         "tailwindcss": "4.1.3"
       },
       "devDependencies": {
         "@eslint/js": "9.24.0",
         "@microsoft/eslint-formatter-sarif": "3.1.0",
-        "@types/react": "19.1.0",
-        "@types/react-dom": "19.0.4",
+        "@types/react": "19.1.1",
+        "@types/react-dom": "19.1.2",
         "@vitejs/plugin-react": "4.3.4",
         "eslint": "9.24.0",
         "eslint-plugin-import": "2.31.0",
@@ -1842,9 +1843,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1852,9 +1853,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
-      "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
+      "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5359,6 +5360,15 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6297,10 +6307,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/website": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -13,13 +13,13 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwindcss": "4.1.3",
-    "website": "file:"
+    "react-icons": "5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "9.24.0",
     "@microsoft/eslint-formatter-sarif": "3.1.0",
-    "@types/react": "19.1.0",
-    "@types/react-dom": "19.0.4",
+    "@types/react": "19.1.1",
+    "@types/react-dom": "19.1.2",
     "@vitejs/plugin-react": "4.3.4",
     "eslint": "9.24.0",
     "eslint-plugin-import": "2.31.0",

--- a/website/src/components/LinkList.tsx
+++ b/website/src/components/LinkList.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react"
-import { IconType } from "react-icons";
-import { IoFolderSharp } from "react-icons/io5";
+import { IconType } from "react-icons"
+import { IoFolderSharp } from "react-icons/io5"
 interface LinkItem {
   id: string
   title: string
@@ -13,8 +13,8 @@ const links: LinkItem[] = [
     id: "github-stats",
     title: "github-stats",
     url: "https://github.com/JackPlowman/github-stats",
-    Icon : IoFolderSharp,
-  }
+    Icon: IoFolderSharp,
+  },
 ]
 
 export const LinkList: FC = () => {
@@ -29,7 +29,7 @@ export const LinkList: FC = () => {
             className="flex items-center rounded-lg bg-stone-100 p-4 shadow transition-shadow duration-200 hover:shadow-md"
             aria-label={`Link to ${title}`}
           >
-            <Icon className="mr-4 h-8 w-8"/>
+            <Icon className="mr-4 h-8 w-8" />
             <span className="text-lg text-stone-800">{title}</span>
           </a>
         </li>

--- a/website/src/components/LinkList.tsx
+++ b/website/src/components/LinkList.tsx
@@ -1,37 +1,26 @@
 import { FC } from "react"
-
+import { IconType } from "react-icons";
+import { IoFolderSharp } from "react-icons/io5";
 interface LinkItem {
   id: string
   title: string
   url: string
-  imageUrl: string
+  Icon: IconType
 }
 
 const links: LinkItem[] = [
   {
-    id: "github",
-    title: "GitHub",
-    url: "https://github.com/JackPlowman",
-    imageUrl: "/github-mark.svg",
-  },
-  {
-    id: "linkedin",
-    title: "LinkedIn",
-    url: "https://linkedin.com/in/jackplowman",
-    imageUrl: "/linkedin.svg",
-  },
-  {
-    id: "twitter",
-    title: "Twitter",
-    url: "https://twitter.com/jack_plowman",
-    imageUrl: "/twitter.svg",
-  },
+    id: "github-stats",
+    title: "github-stats",
+    url: "https://github.com/JackPlowman/github-stats",
+    Icon : IoFolderSharp,
+  }
 ]
 
 export const LinkList: FC = () => {
   return (
     <ul className="w-full max-w-md space-y-6" aria-label="List of Links">
-      {links.map(({ id, title, url, imageUrl }) => (
+      {links.map(({ id, title, url, Icon }) => (
         <li key={id}>
           <a
             href={url}
@@ -40,11 +29,7 @@ export const LinkList: FC = () => {
             className="flex items-center rounded-lg bg-stone-100 p-4 shadow transition-shadow duration-200 hover:shadow-md"
             aria-label={`Link to ${title}`}
           >
-            <img
-              src={imageUrl}
-              alt={`${title} logo`}
-              className="mr-4 h-8 w-8"
-            />
+            <Icon className="mr-4 h-8 w-8"/>
             <span className="text-lg text-stone-800">{title}</span>
           </a>
         </li>


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to dependencies and changes to the `LinkList` component to use icons from the `react-icons` library instead of image URLs.

### Dependency Updates:
* Added `react-icons` version `5.5.0` to dependencies in `website/package.json` and `website/package-lock.json`. [[1]](diffhunk://#diff-999051457a1934c824a5f8395589ea5e749a581e9f70a43585c885319cb56e64R13-R20) [[2]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L16-R22)
* Updated `@types/react` to version `19.1.1` and `@types/react-dom` to version `19.1.2` in `website/package.json` and `website/package-lock.json`. [[1]](diffhunk://#diff-999051457a1934c824a5f8395589ea5e749a581e9f70a43585c885319cb56e64R13-R20) [[2]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L16-R22)

### Codebase Changes:
* Removed the `website` dependency from `website/package.json` and `website/package-lock.json`. [[1]](diffhunk://#diff-999051457a1934c824a5f8395589ea5e749a581e9f70a43585c885319cb56e64L6301-L6304) [[2]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L16-R22)
* Modified `LinkList` component to use icons from `react-icons` instead of image URLs:
  * Imported `IconType` and `IoFolderSharp` from `react-icons/io5`.
  * Updated `LinkItem` interface to use `Icon` instead of `imageUrl`.
  * Changed the `links` array to include an icon for each link.
  * Replaced the `<img>` element with the `<Icon>` component in the `LinkList` rendering logic.