### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -217,6 +217,5 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.15


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes a custom CodeQL configuration file and updates the workflow to no longer use it. The changes streamline the CodeQL analysis process by relying on default configurations.

CodeQL configuration updates:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the custom query filter that excluded the `actions/unpinned-tag` query.

Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L220): Removed the reference to the deleted CodeQL configuration file from the `config-file` parameter in the CodeQL analysis step.