### PR TITLE
Bump GitHub Action Versions

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       with:
         pyproject-file: "tests/pyproject.toml"
         enable-cache: true

--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -9,8 +9,7 @@ runs:
     - name: Install Python and UV
       uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       with:
-        pyproject-file: "tests/pyproject.toml"
-        enable-cache: true
+        working-directory: tests
     - name: Install Playwright Dependencies
       shell: bash
       run: just tests::playwright-install-minimum

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
-          version: "latest"
+          working-directory: tests
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif
         env:
@@ -193,7 +193,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
-          version: "latest"
+          working-directory: tests
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -168,7 +168,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -191,7 +191,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `setup-uv` GitHub Action to version 6.0.1 across multiple workflow files to ensure compatibility with the latest features and improvements.

### Dependency updates:

* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L10-R10): Updated the `setup-uv` action from version 5.4.2 to 6.0.1 for Python and UV installation.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L171-R171): Updated the `setup-uv` action from version 5.4.2 to 6.0.1 in two separate jobs for installing the latest version of UV. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L171-R171) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L194-R194)