### PR TITLE
Add CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -219,3 +219,18 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.15
+
+  run-codelimit:
+    name: Run CodeLimit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Run CodeLimit"
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to integrate the CodeLimit tool for repository analysis. The most important change is the addition of the `run-codelimit` job in the `.github/workflows/code-checks.yml` file.

### GitHub Actions Workflow Update:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R222-R236): Added a new `run-codelimit` job to execute the CodeLimit analysis tool. This includes setting up permissions, checking out the repository, and running the `getcodelimit/codelimit-action` action.