### PR TITLE
Fix Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install, build, and upload your site
         uses: withastro/action@v3.0.2
         with:
-          path: dashboard
+          path: website
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the deployment workflow configuration to ensure the correct directory is used during the build process.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L32-R32): Changed the `path` parameter from `dashboard` to `website` in the `withastro/action` step to align with the updated project structure.
