### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install, build, and upload your site
-        uses: withastro/action@v3.0.2
+        uses: withastro/action@56781b97402ce0487b7e61ce2cb960c0e2cc5289 # v3.0.2
         with:
           path: website
 
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@v1.11.0
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: https://jackplowman.github.io/project-links
           recurse: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow in `.github/workflows/deploy.yml` to use specific commit SHAs for actions instead of version tags, improving security and reliability.

### Workflow updates:

* Updated the `withastro/action` GitHub Action to use the specific commit SHA `56781b97402ce0487b7e61ce2cb960c0e2cc5289` instead of the version tag `v3.0.2`.
* Updated the `JustinBeckwith/linkinator-action` GitHub Action to use the specific commit SHA `3d5ba091319fa7b0ac14703761eebb7d100e6f6d` instead of the version tag `v1.11.0`.