### PR TITLE
Fix Deploy Workflow 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3.0.1
         with:
           # Upload dist folder
-          path: './dist'
+          path: "./dist"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          # Upload dist folder
-          path: "./dist"
+          path: "website/dist"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,26 +14,8 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  build-site:
+  build-and-deploy:
     name: Build Site
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      pages: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install, build, and upload your site
-        uses: withastro/action@56781b97402ce0487b7e61ce2cb960c0e2cc5289 # v3.0.2
-        with:
-          path: website
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build-site
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -42,6 +24,20 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Website Dependencies
+        uses: ./.github/actions/setup-website-dependencies
+      - name: Setup Pages
+        uses: actions/configure-pages@v5.0.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          # Upload dist folder
+          path: './dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
@@ -49,7 +45,7 @@ jobs:
   link-tests:
     name: Link Tests
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: build-and-deploy
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
           persist-credentials: false
       - name: Setup Website Dependencies
         uses: ./.github/actions/setup-website-dependencies
+      - name: Build Website
+        run: just website::build
       - name: Setup Pages
         uses: actions/configure-pages@v5.0.0
       - name: Upload artifact

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -5,4 +5,5 @@ import { defineConfig } from "vite"
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  base: "/project-links/",
 })


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a streamlined deployment workflow and a minor configuration update for the website. The most significant changes include merging the build and deploy jobs into a single job in the GitHub Actions workflow and updating the Vite configuration to set a base path for the project.

### Workflow improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L17-R49): Combined the `build-site` and `deploy` jobs into a single `build-and-deploy` job to simplify the workflow. Added steps for setting up dependencies, building the website, configuring GitHub Pages, and uploading artifacts. Updated the `link-tests` job to depend on `build-and-deploy` instead of `deploy`.

### Configuration updates:
* [`website/vite.config.ts`](diffhunk://#diff-230359fd30686ac9bcb5f851d99fd24dd423628039d8b82dd52b99f09fb02270R8): Added a `base` property to the Vite configuration to set the base path for the project as `/project-links/`.