### PR TITLE
Add Title Tests

### DIFF
--- a/tests/ui/constants.py
+++ b/tests/ui/constants.py
@@ -1,1 +1,0 @@
-DEFAULT_URL = "https://jackplowman.github.io/project-links"

--- a/tests/ui/environment_variables.py
+++ b/tests/ui/environment_variables.py
@@ -1,0 +1,3 @@
+from os import getenv
+
+project_url = getenv("PROJECT_URL")

--- a/tests/ui/test_metadata.py
+++ b/tests/ui/test_metadata.py
@@ -1,14 +1,13 @@
-from .constants import DEFAULT_URL
 from playwright.sync_api import Page
+
+from .environment_variables import project_url
+
 
 def test_title(page: Page) -> None:
     """Test the title of the website."""
     # Arrange
-    page.goto(DEFAULT_URL)
+    page.goto(project_url)
     # Act
     title = page.title()
     # Assert
-    assert title == "Project Links"
-
-
-
+    assert title == "Jack's Project Links"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new test to validate the website's title and sets up an environment variable to manage the project's URL. The most important changes include importing the `PROJECT_URL` environment variable and creating a test for the website's title.

### Test implementation:

* [`tests/ui/test_metadata.py`](diffhunk://#diff-1e7e86c0ec0c55344ec4f7908c622d1271b7b5a0e853cb5bb347a11509dc2fe0R1-R13): Added a new test, `test_title`, to verify that the website's title matches the expected value, "Jack's Project Links." This test uses the `Page` object from Playwright to navigate to the URL and retrieve the title.

### Environment variable setup:

* [`tests/ui/environment_variables.py`](diffhunk://#diff-67c11d36d216abe57cfb024866467da79864c232c84deb363ce1cbdb91df7e31R1-R3): Added code to import the `PROJECT_URL` environment variable using Python's `getenv` function, enabling dynamic configuration of the project URL.
