### PR TITLE
Swap npm Install to npm ci

### DIFF
--- a/.github/actions/setup-website-dependencies/action.yml
+++ b/.github/actions/setup-website-dependencies/action.yml
@@ -16,4 +16,4 @@ runs:
 
     - name: Install Website Dependencies
       shell: bash
-      run: just website::install
+      run: just website::ci

--- a/website/website.just
+++ b/website/website.just
@@ -6,6 +6,10 @@
 install:
     npm install
 
+# Install Node Dependencies
+ci:
+    npm ci
+
 # Start the development server
 dev:
     npm run dev


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the process for installing website dependencies to align with CI best practices by introducing a new `ci` target in the `just` task file and updating the corresponding GitHub Actions workflow.

Updates to dependency installation:

* [`.github/actions/setup-website-dependencies/action.yml`](diffhunk://#diff-24c40199d9151f1a7883d7762d9a3f740e2270022992b08acae64e63fa738b1aL19-R19): Updated the `run` command from `just website::install` to `just website::ci` to use the new CI-specific installation process.
* [`website/website.just`](diffhunk://#diff-61a212e7e062864312333ce882537d3b0eccd3c0bdae96e76de4fd7d537307b6R9-R12): Added a new `ci` target that uses `npm ci` for installing Node dependencies, which is more suitable for CI environments as it ensures a clean and reproducible install.