### PR TITLE
Run Tests in Multiple Browsers

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -1,6 +1,12 @@
 name: "Setup Test Dependencies"
 description: "Installs dependencies for the project"
 
+inputs:
+  setup-browsers:
+    description: "Whether to install browsers for Playwright"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -11,6 +17,7 @@ runs:
       with:
         working-directory: tests
     - name: Install Playwright Dependencies
+      if: ${{ inputs.setup-browsers == 'true' }}
       shell: bash
       run: just tests::playwright-install-minimum
     - name: Install Python Dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    name: Build Site
+    name: Build Site and Deploy to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/deploy-pages@v4.0.5
 
   ui-tests:
-    name: UI Tests
+    name: Run UI Tests in ${ matrix.browser }
     runs-on: ubuntu-latest
     needs: build-and-deploy
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,10 @@ jobs:
     name: UI Tests
     runs-on: ubuntu-latest
     needs: build-and-deploy
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [firefox, webkit, chromium, edge]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -59,7 +63,9 @@ jobs:
         shell: bash
         run: just tests::playwright-install
       - name: Run UI Tests
-        run: just tests::run
+        run: just tests::run-in-browser
+        env:
+          BROWSER: ${{ matrix.browser }}
 
   link-tests:
     name: Link Tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
           persist-credentials: false
       - name: Set up Python Tests Dependencies
         uses: ./.github/actions/setup-test-dependencies
+        with:
+          setup-browsers: true
       - name: Install Playwright Dependencies
         shell: bash
         run: just tests::playwright-install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/deploy-pages@v4.0.5
 
   ui-tests:
-    name: Run UI Tests in ${ matrix.browser }
+    name: Run UI Tests in ${{ matrix.browser }}
     runs-on: ubuntu-latest
     needs: build-and-deploy
     strategy:

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -26,8 +26,6 @@ run-local:
 playwright-install:
     uv run playwright install
 
-
-
 # Remove all compiled Python files
 clean:
     find . \( \

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -6,10 +6,15 @@
 install:
     uv sync --all-extras
 
-# Run End-to-End Tests
+# Run End-to-End Tests in chromium
 run:
     PROJECT_URL=https://jackplowman.github.io/project-links \
     uv run pytest ui -vv --reruns 2
+
+# Run End-to-End Tests in browser
+run-in-browser:
+    PROJECT_URL=https://jackplowman.github.io/project-links \
+    uv run pytest ui -vv --reruns 2 --browser ${BROWSER}
 
 # Run End-to-End Tests with dashboard running locally
 run-local:
@@ -21,9 +26,7 @@ run-local:
 playwright-install:
     uv run playwright install
 
-# Install playwright minimum dependencies
-playwright-install-minimum:
-    uv run playwright install --with-deps --only-shell chromium
+
 
 # Remove all compiled Python files
 clean:


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces enhancements to the test and deployment workflows, focusing on improved browser testing support and updated deployment naming conventions. Key changes include adding browser matrix testing for UI tests, updating workflow job names, and refining Playwright dependency installation.

### Enhancements to browser testing:

* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144R4-R9): Added a new input `setup-browsers` to optionally install browsers for Playwright, with a default value of `false`. This allows more flexibility in configuring test dependencies.  
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L47-R53): Introduced a browser matrix strategy for the `ui-tests` job, enabling tests to run across multiple browsers (`firefox`, `webkit`, `chromium`, `edge`). Updated the test execution to use the `setup-browsers` input and pass the selected browser to the test runner. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L47-R53) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R62-R70)  
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L9-R18): Added a new `run-in-browser` command to run end-to-end tests in a specified browser, leveraging the `BROWSER` environment variable.  

### Workflow improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L18-R18): Updated the `build-and-deploy` job name to "Build Site and Deploy to GitHub Pages" for clarity.  
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L47-R53): Renamed the `ui-tests` job to include the browser name dynamically, improving visibility into test execution.  

### Simplification of Playwright setup:

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L24-L27): Removed the `playwright-install-minimum` command, as the new workflow setup ensures all necessary dependencies are installed through the `setup-browsers` input.