### PR TITLE
Fix Deploy Workflow 5

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install Playwright Dependencies
       if: ${{ inputs.setup-browsers == 'true' }}
       shell: bash
-      run: just tests::playwright-install-minimum
+      run: just tests::playwright-install
     - name: Install Python Dependencies
       shell: bash
       run: just tests::install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [firefox, webkit, chromium, edge]
+        browser: [firefox, chromium]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions configuration files to streamline test dependencies and deployment workflows. The most significant changes involve modifying the Playwright installation command and reducing the browser matrix for deployment jobs.

### Updates to GitHub Actions:

* [`.github/actions/setup-test-dependencies/action.yml`](diffhunk://#diff-ee1e9a84357cfd23d067400706d92b6bb9d8fd8744e81563d9858e8c344df144L22-R22): Updated the Playwright installation command to use `just tests::playwright-install` instead of the minimum installation command, ensuring all necessary dependencies are installed.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L53-R53): Reduced the browser matrix for deployment jobs by removing `webkit` and `edge`, leaving only `firefox` and `chromium` for testing. This simplifies the workflow and focuses on key browsers.