### PR TITLE
Add Webkit Testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,28 @@ jobs:
         env:
           BROWSER: ${{ matrix.browser }}
 
+  ui-tests-webkit:
+    name: Run UI Tests in WebKit
+    runs-on: macos-latest
+    needs: build-and-deploy
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python Tests Dependencies
+        uses: ./.github/actions/setup-test-dependencies
+        with:
+          setup-browsers: true
+      - name: Install Playwright Dependencies
+        shell: bash
+        run: just tests::playwright-install
+      - name: Run UI Tests
+        run: just tests::run-in-browser
+        env:
+          BROWSER: webkit
+
   link-tests:
     name: Link Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [firefox, chromium]
+        browser: [firefox, chromium, webkit]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -68,28 +68,6 @@ jobs:
         run: just tests::run-in-browser
         env:
           BROWSER: ${{ matrix.browser }}
-
-  ui-tests-webkit:
-    name: Run UI Tests in WebKit
-    runs-on: macos-latest
-    needs: build-and-deploy
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Python Tests Dependencies
-        uses: ./.github/actions/setup-test-dependencies
-        with:
-          setup-browsers: true
-      - name: Install Playwright Dependencies
-        shell: bash
-        run: just tests::playwright-install
-      - name: Run UI Tests
-        run: just tests::run-in-browser
-        env:
-          BROWSER: webkit
 
   link-tests:
     name: Link Tests

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -24,7 +24,7 @@ run-local:
 
 # Install playwright dependencies
 playwright-install:
-    uv run playwright install
+    uv run playwright install --with-deps
 
 # Remove all compiled Python files
 clean:


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces updates to the browser testing configuration and ensures all necessary dependencies are installed for Playwright. These changes enhance browser coverage and improve the reliability of local test setup.

### Browser testing updates:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L53-R53): Added `webkit` to the browser matrix for testing, expanding coverage to include an additional browser.

### Playwright setup improvement:
* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918L27-R27): Modified the Playwright installation command to include `--with-deps`, ensuring all required dependencies are installed for local testing.
