### PR TITLE
Document Test Command

### DIFF
--- a/tests/tests.just
+++ b/tests/tests.just
@@ -20,6 +20,7 @@ run $PROJECT_URL=DEFAULT_PROJECT_URL $browser="chromium":
 run-local $project_url="http://localhost:8000":
     just tests::run ${project_url}
 
+# Run End-to-End Tests in a specific browser
 run-ci $browser:
     just tests::run $DEFAULT_PROJECT_URL ${browser}
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new command to the `tests/tests.just` file, allowing End-to-End tests to be run in a specific browser by specifying the `$browser` parameter.

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R23): Added a `run-ci` command to execute End-to-End tests with a specified browser, defaulting to the `$DEFAULT_PROJECT_URL`.