### PR TITLE
Add website sitemap

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -30,7 +30,8 @@
         "prettier-plugin-tailwindcss": "0.6.11",
         "typescript": "5.8.3",
         "typescript-eslint": "8.29.1",
-        "vite": "6.2.6"
+        "vite": "6.2.6",
+        "vite-plugin-sitemap": "^0.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6307,6 +6308,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-plugin-sitemap": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-sitemap/-/vite-plugin-sitemap-0.7.1.tgz",
+      "integrity": "sha512-4NRTkiWytLuAmcikckrLcLl9iYA20+5v6l8XshcOrzxH1WR8H0O3S6sTQYfjMrE8su/LG6Y0cTodvOdcOIxaLw==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -12,8 +12,8 @@
     "@tailwindcss/vite": "4.1.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwindcss": "4.1.3",
-    "react-icons": "5.5.0"
+    "react-icons": "5.5.0",
+    "tailwindcss": "4.1.3"
   },
   "devDependencies": {
     "@eslint/js": "9.24.0",
@@ -32,6 +32,7 @@
     "prettier-plugin-tailwindcss": "0.6.11",
     "typescript": "5.8.3",
     "typescript-eslint": "8.29.1",
-    "vite": "6.2.6"
+    "vite": "6.2.6",
+    "vite-plugin-sitemap": "0.7.1"
   }
 }

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,9 +1,10 @@
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+import Sitemap from "vite-plugin-sitemap"
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), Sitemap()],
   base: "/project-links/",
 })


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the `vite-plugin-sitemap` package to the project, enabling automatic sitemap generation for the website. The changes include updates to dependencies, configuration adjustments, and integration of the plugin into the Vite build process.

### Dependency Updates:
* Added `vite-plugin-sitemap` version `0.7.1` to both `dependencies` in `website/package.json` and `node_modules` in `website/package-lock.json`. [[1]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L35-R36) [[2]](diffhunk://#diff-999051457a1934c824a5f8395589ea5e749a581e9f70a43585c885319cb56e64L33-R34) [[3]](diffhunk://#diff-999051457a1934c824a5f8395589ea5e749a581e9f70a43585c885319cb56e64R6312-R6317)

### Configuration Changes:
* Updated `website/vite.config.ts` to include `vite-plugin-sitemap` in the Vite plugins array, ensuring the sitemap is generated during the build process.