### PR TITLE
Add Sitemap Test

### DIFF
--- a/tests/ui/test_metadata.py
+++ b/tests/ui/test_metadata.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import Page
 from requests import get
+
 from .environment_variables import project_url
 
 
@@ -12,12 +13,13 @@ def test_title(page: Page) -> None:
     # Assert
     assert title == "Jack's Project Links"
 
+
 def test_sitemap() -> None:
     """Test the sitemap of the website."""
     # Arrange
     sitemap_url = f"{project_url}/sitemap.xml"
     # Act
-    response = get(sitemap_url)
+    response = get(sitemap_url, timeout=5)
     # Assert
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/xml"

--- a/tests/ui/test_metadata.py
+++ b/tests/ui/test_metadata.py
@@ -1,5 +1,5 @@
 from playwright.sync_api import Page
-
+from requests import get
 from .environment_variables import project_url
 
 
@@ -11,3 +11,14 @@ def test_title(page: Page) -> None:
     title = page.title()
     # Assert
     assert title == "Jack's Project Links"
+
+def test_sitemap() -> None:
+    """Test the sitemap of the website."""
+    # Arrange
+    sitemap_url = f"{project_url}/sitemap.xml"
+    # Act
+    response = get(sitemap_url)
+    # Assert
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/xml"
+    assert "<urlset" in response.text


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new test to verify the sitemap functionality of the website. It introduces a new dependency and includes assertions to ensure the sitemap is accessible and correctly formatted.

### Additions to testing:
* [`tests/ui/test_metadata.py`](diffhunk://#diff-1e7e86c0ec0c55344ec4f7908c622d1271b7b5a0e853cb5bb347a11509dc2fe0R15-R26): Added a new `test_sitemap` function to validate the sitemap's availability, status code, content type, and structure.

### Dependency updates:
* [`tests/ui/test_metadata.py`](diffhunk://#diff-1e7e86c0ec0c55344ec4f7908c622d1271b7b5a0e853cb5bb347a11509dc2fe0R2): Imported the `get` function from the `requests` library to facilitate HTTP requests for the sitemap test.