### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
       - ".github/actions/setup-test-dependencies"
       - ".github/actions/setup-website-dependencies"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,9 +21,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "website"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -37,9 +35,8 @@ updates:
   - package-ecosystem: "uv"
     directory: "tests"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       - ".github/actions/setup-website-dependencies"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,7 +22,7 @@ updates:
     directory: "website"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       typescript:
@@ -36,7 +36,7 @@ updates:
     directory: "tests"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration in `.github/dependabot.yml` to standardize the scheduling format for dependency updates by replacing the `interval`, `time`, and `timezone` fields with a single `cronjob` field.

Key changes:

### Scheduling updates:

* Replaced the `interval`, `time`, and `timezone` fields with a `cronjob` field set to `"30 7 * * *"` for the following dependency update configurations:
  - GitHub Actions dependencies in `.github/actions/setup-test-dependencies` and `.github/actions/setup-website-dependencies`.
  - `npm` dependencies in the `website` directory.
  - `uv` dependencies in the `tests` directory.