### PR TITLE
Swap SuperLinter to Full Version

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/code-checks.yml` file. The change updates the GitHub Action for linting by switching from the `super-linter/super-linter/slim` version to the standard `super-linter/super-linter` version while maintaining the same commit reference for versioning.