### PR TITLE
Migrate Clear Caches to Common Clear Caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -5,20 +5,13 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   clean-caches:
-    name: Clean GitHub Action Caches
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Delete caches
-        run: gh cache delete --all --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    name: Clean Caches
+    permissions:
+      contents: read
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    secrets:
+      workflow_github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the `.github/workflows/clean-caches.yml` workflow to simplify its implementation by reusing a shared workflow. The most notable changes involve replacing the inline job definition with a reference to a reusable workflow and adjusting permissions and secrets accordingly.

### Workflow refactoring:

* Replaced the inline `clean-caches` job definition with a reference to the reusable workflow `common-clean-caches.yml` from an external repository. This reduces duplication and centralizes maintenance.
* Updated `permissions` to an empty object (`{}`) at the top level and specified `contents: read` within the reusable workflow configuration.
* Removed the explicit steps for checking out the repository and deleting caches, as these are now handled by the reusable workflow.
* Added a `secrets` section to pass the `GH_TOKEN` as `workflow_github_token` to the reusable workflow.