### PR TITLE
Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -131,28 +131,17 @@ jobs:
         env:
           RUFF_OUTPUT_FORMAT: "github"
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, typescript, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        language: [actions, typescript, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   run-codelimit:
     name: Run CodeLimit


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to improve maintainability and streamline its configuration by switching to a reusable workflow. The most important changes are listed below:

### Workflow configuration updates:

* Renamed the `run-codeql-analysis` job to `codeql-checks` for better clarity.
* Replaced the inline CodeQL setup and analysis steps with a reusable workflow (`JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml`) to simplify the workflow definition and ensure consistency.

### Permissions and matrix adjustments:

* Updated job permissions by changing `statuses: write` to `contents: read` while retaining `security-events: write` for improved security.
* Rearranged the `matrix.language` values to `[actions, typescript, python]` for consistency.