### PR TITLE
Set Zizmor Persona to Auditor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `Justfile`. The change updates the `zizmor-check` persona from `pedantic` to `auditor` in the `lefthook-validate` section.