### PR TITLE
Remove CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -187,18 +187,3 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     with:
       language: ${{ matrix.language }}
-
-  run-codelimit:
-    name: Run CodeLimit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `run-codelimit` job from the `.github/workflows/code-checks.yml` file. The deletion simplifies the workflow by eliminating steps related to the CodeLimit tool.