### PR TITLE
Remove Recursive Workflow Link Checking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,6 @@ jobs:
         uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: https://jackplowman.github.io/project-links
-          recurse: true
+          recurse: false
           timeout: 1000
           markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor change to the `.github/workflows/deploy.yml` file. The `recurse` option in the `linkinator-action` configuration was updated from `true` to `false`.