### PR TITLE
Swap linkinator to linkcheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,9 +80,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
+        uses: filiph/linkcheck@f2c15a0be0d9c83def5df3edcc0f2d6582845f2d # 3.0.0
         with:
-          paths: https://jackplowman.github.io/project-links
-          recurse: false
-          timeout: 1000
-          markdown: false
+          arguments: https://jackplowman.github.io/project-links


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the link-checking tool used in the deployment workflow to a newer version with a different action. The most important change is the replacement of the `linkinator-action` with `linkcheck`, along with adjustments to its configuration.

Workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L83-R85): Replaced `JustinBeckwith/linkinator-action` (v1.11.0) with `filiph/linkcheck` (v3.0.0) for link testing. Updated the configuration to use the `arguments` parameter instead of `paths`, and removed unused parameters (`recurse`, `timeout`, `markdown`).