### PR TITLE
Update license to licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the documentation configuration in `.github/other-configurations/labeller.yml`. The change corrects the spelling of the license file pattern from `LICENSE` to `LICENCE`.