### PR TITLE
Update Minimum UV Version

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 dev = ["ruff==0.12.0", "ty==0.0.1a11"]
 
 [tool.uv]
-required-version = "0.7.13"
+required-version = "~=0.8.0"
 package = false
 
 [tool.ruff]


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the required version of the `uv` tool in the `tests/pyproject.toml` configuration file to allow compatibility with any `0.8.x` version, instead of requiring exactly `0.7.13`.

- Dependency versioning:
  * Updated the `[tool.uv] required-version` to `"~=0.8.0"` to support all compatible `0.8.x` releases instead of pinning to `0.7.13`.