### PR TITLE
Update Ruff Configuration

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -39,26 +39,6 @@ ignore = [
 fixable = ["ALL"]
 unfixable = []
 
-exclude = [
-  ".bzr",
-  ".direnv",
-  ".eggs",
-  ".git",
-  ".hg",
-  ".mypy_cache",
-  ".nox",
-  ".pants.d",
-  ".pytype",
-  ".ruff_cache",
-  ".svn",
-  ".tox",
-  ".venv",
-  "__pypackages__",
-  "_build",
-]
-
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
 [tool.ruff.lint.per-file-ignores]
 "**test_*.py" = ["S101", "D102", "D103", "SLF001", "PT019"]
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the Ruff linter configuration in `tests/pyproject.toml`, specifically removing the `exclude` list and `dummy-variable-rgx` settings. This simplifies the configuration and may affect which files Ruff lints in the test environment.

- Removed the `exclude` list and `dummy-variable-rgx` configuration from `[tool.ruff.lint]` in `tests/pyproject.toml`, potentially broadening the scope of files checked by Ruff and simplifying the config.
